### PR TITLE
Implement document plugin loader

### DIFF
--- a/pkg/document/bundle.go
+++ b/pkg/document/bundle.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 
+	docplugins "opendev.org/airship/airshipctl/pkg/document/plugins"
 	utilyaml "opendev.org/airship/airshipctl/pkg/util/yaml"
 )
 
@@ -78,6 +79,7 @@ func NewBundle(fSys fs.FileSystem, kustomizePath string, outputPath string) (Bun
 
 	pluginConfig := plugins.DefaultPluginConfig()
 	pl := plugins.NewLoader(pluginConfig, rf)
+	plugins.TransformerFactories[plugins.Unknown] = docplugins.NewTransformerLoader
 
 	ldr, err := loader.NewLoader(
 		bundle.GetKustomizeBuildOptions().LoadRestrictor, v, bundle.GetKustomizeBuildOptions().KustomizationPath, fSys)

--- a/pkg/document/plugins/errors.go
+++ b/pkg/document/plugins/errors.go
@@ -1,0 +1,12 @@
+package plugins
+
+import "fmt"
+
+// UnknownPluginError raised for unkregistered plugin kinds
+type UnknownPluginError struct {
+	Kind string
+}
+
+func (e UnknownPluginError) Error() string {
+	return fmt.Sprintf("Unknown airship plugin with Kind: %s", e.Kind)
+}

--- a/pkg/document/plugins/loader.go
+++ b/pkg/document/plugins/loader.go
@@ -1,0 +1,45 @@
+package plugins
+
+import (
+	"sigs.k8s.io/kustomize/v3/pkg/ifc"
+	"sigs.k8s.io/kustomize/v3/pkg/resid"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/yaml"
+)
+
+// PluginRegistry map of plugin kinds to plugin instance
+var PluginRegistry = make(map[string]resmap.TransformerPlugin)
+
+// TransformerLoader airship document plugin loader. Loads
+type TransformerLoader struct {
+	resid.ResId
+}
+
+// Config reads plugin configuration structure
+func (l *TransformerLoader) Config(
+	ldr ifc.Loader, rf *resmap.Factory, c []byte) error {
+	if err := yaml.Unmarshal(c, l); err != nil {
+		return err
+	}
+	airshipPlugin, found := PluginRegistry[l.Kind]
+	if !found {
+		return UnknownPluginError{Kind: l.Kind}
+	}
+	cfg := airshipPlugin.(resmap.Configurable)
+	return cfg.Config(ldr, rf, c)
+}
+
+// Transform run plugin's Transorm method
+func (l *TransformerLoader) Transform(m resmap.ResMap) error {
+	airshipPlugin, found := PluginRegistry[l.Kind]
+	if !found {
+		return UnknownPluginError{Kind: l.Kind}
+	}
+	transformer := airshipPlugin.(resmap.Transformer)
+	return transformer.Transform(m)
+}
+
+// NewTransformerLoader returns aitship document plugin transformer
+func NewTransformerLoader() resmap.TransformerPlugin {
+	return &TransformerLoader{}
+}

--- a/pkg/document/plugins/loader_test.go
+++ b/pkg/document/plugins/loader_test.go
@@ -1,0 +1,17 @@
+package plugins_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"opendev.org/airship/airshipctl/pkg/document"
+	"opendev.org/airship/airshipctl/testutil"
+)
+
+func TestLoaderConfig(t *testing.T) {
+	t.Run("Try load non-existent plugin", func(t *testing.T) {
+		_, err := document.NewBundle(testutil.SetupTestFs(t, "testdata/unknownplugin"), "/", "/")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/document/plugins/testdata/unknownplugin/dummyplugin.yaml
+++ b/pkg/document/plugins/testdata/unknownplugin/dummyplugin.yaml
@@ -1,0 +1,4 @@
+apiVersion: builtin
+kind: SomeKind
+metadata:
+  name: notImportantHere

--- a/pkg/document/plugins/testdata/unknownplugin/kustomization.yaml
+++ b/pkg/document/plugins/testdata/unknownplugin/kustomization.yaml
@@ -1,0 +1,2 @@
+transformers:
+  - dummyplugin.yaml


### PR DESCRIPTION
Loader assosiated with Unknown type of a transformer kustomize plugin
and considered 'builtin'. Kustomize plugin system executes Config and
Transform meththod of buildtin plugins. Therefore appropriate mathos
of the document plugin loaders are executed as well. Main goal for
airship document plugin loaded is to detrmine desired aitship plugin
based on Kind field end execute its Config or Transform methods

Change-Id: Ic26a880570491ac3a59f2357ed455a2a7362387b