### PR TITLE
Add Subtree inserter plugin

### DIFF
--- a/pkg/document/plugins/loader_test.go
+++ b/pkg/document/plugins/loader_test.go
@@ -9,7 +9,7 @@ import (
 	"opendev.org/airship/airshipctl/testutil"
 )
 
-func TestLoaderConfig(t *testing.T) {
+func TestLoader(t *testing.T) {
 	t.Run("Try load non-existent plugin", func(t *testing.T) {
 		_, err := document.NewBundle(testutil.SetupTestFs(t, "testdata/unknownplugin"), "/", "/")
 		assert.Error(t, err)

--- a/pkg/document/plugins/plugin_treeinserter.go
+++ b/pkg/document/plugins/plugin_treeinserter.go
@@ -1,0 +1,76 @@
+package plugins
+
+import (
+	"bytes"
+	"html/template"
+
+	"sigs.k8s.io/kustomize/v3/pkg/gvk"
+	"sigs.k8s.io/kustomize/v3/pkg/ifc"
+	"sigs.k8s.io/kustomize/v3/pkg/resid"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/yaml"
+)
+
+func init() {
+	PluginRegistry["TreeInserter"] = NewTreeInserterPlugin()
+}
+
+// TreeInserter plugin to insert map subtree from specified resource
+type TreeInserter struct {
+	resid.ResId
+}
+
+// Config loads configuration from plugin config
+func (ti *TreeInserter) Config(
+	ldr ifc.Loader, rf *resmap.Factory, c []byte) error {
+	return yaml.Unmarshal(c, ti)
+}
+
+// Transform applies transformation to all resources
+func (ti *TreeInserter) Transform(m resmap.ResMap) error {
+	for _, r := range m.Resources() {
+		rm := r.Map()
+		ModifyHashStrings(rm, m, renderString)
+	}
+	return nil
+}
+
+// NewTreeInserterPlugin returns plugin instance
+func NewTreeInserterPlugin() resmap.TransformerPlugin {
+	return &TreeInserter{}
+}
+
+func renderString(in string, rm resmap.ResMap) (string, error) {
+	tmpl, err := template.New("tmpl").Funcs(
+		template.FuncMap{
+			"getTreeByPath": getTreeByPath,
+		},
+	).Parse(in)
+	if err != nil {
+		return "", nil
+	}
+	buf := &bytes.Buffer{}
+	err = tmpl.Execute(buf, rm)
+	if err != nil {
+		return "", nil
+	}
+	return buf.String(), nil
+
+}
+
+func getTreeByPath(resourceGVK, name, path string, rm resmap.ResMap) (string, error) {
+	filterResID := resid.NewResId(gvk.FromString(resourceGVK), name)
+	res, err := rm.GetById(filterResID)
+	if err != nil {
+		return "", err
+	}
+	tree, err := res.GetFieldValue(path)
+	if err != nil {
+		return "", err
+	}
+	result, err := yaml.Marshal(tree)
+	if err != nil {
+		return "", err
+	}
+	return string(result), nil
+}

--- a/pkg/document/plugins/plugin_treeinserter_test.go
+++ b/pkg/document/plugins/plugin_treeinserter_test.go
@@ -1,0 +1,35 @@
+package plugins_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/yaml"
+
+	"opendev.org/airship/airshipctl/pkg/document"
+	"opendev.org/airship/airshipctl/testutil"
+)
+
+func TestTreeInserter(t *testing.T) {
+	t.Run("Transform data", func(t *testing.T) {
+		bundle, err := document.NewBundle(testutil.SetupTestFs(t, "testdata/treeinserter"), "/", "/")
+		assert.NoError(t, err)
+		var resourceToRender document.Document
+		var dataSource document.Document
+		var renderString string
+		var srcMap map[string]interface{}
+		var src []byte
+		resourceToRender, err = bundle.GetByName("resourceToRender")
+		assert.NoError(t, err)
+		dataSource, err = bundle.GetByName("dataSource")
+		assert.NoError(t, err)
+		renderString, err = resourceToRender.GetString("data")
+		assert.NoError(t, err)
+		srcMap, err = dataSource.GetMap("spec.someData")
+		assert.NoError(t, err)
+		src, err = yaml.Marshal(srcMap)
+		assert.NoError(t, err)
+
+		assert.Equal(t, string(src), renderString)
+	})
+}

--- a/pkg/document/plugins/testdata/treeinserter/destination.yaml
+++ b/pkg/document/plugins/testdata/treeinserter/destination.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: MeatBall
+metadata:
+  name: resourceToRender
+data: |
+    {{ getTreeByPath "apps_v2_Beef" "dataSource" "spec.someData" . -}}

--- a/pkg/document/plugins/testdata/treeinserter/kustomization.yaml
+++ b/pkg/document/plugins/testdata/treeinserter/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - source.yaml
+  - destination.yaml
+transformers:
+  - treeinserter.yaml

--- a/pkg/document/plugins/testdata/treeinserter/source.yaml
+++ b/pkg/document/plugins/testdata/treeinserter/source.yaml
@@ -1,0 +1,9 @@
+
+apiVersion: apps/v2
+kind: Beef
+metadata:
+  name: dataSource
+spec:
+  someData:
+    test: data
+    test1: otherData

--- a/pkg/document/plugins/testdata/treeinserter/treeinserter.yaml
+++ b/pkg/document/plugins/testdata/treeinserter/treeinserter.yaml
@@ -1,0 +1,4 @@
+apiVersion: builtin
+kind: TreeInserter
+metadata:
+  name: notImportantHere

--- a/pkg/document/plugins/utils.go
+++ b/pkg/document/plugins/utils.go
@@ -1,0 +1,36 @@
+package plugins
+
+import (
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+)
+
+// ModifyHashStrings goes down the map recursively and tries
+// to apply function to each string
+func ModifyHashStrings(
+	doc interface{},
+	rm resmap.ResMap,
+	fn func(string, resmap.ResMap) (string, error),
+) (interface{}, error) {
+	var err error
+	switch typeV := doc.(type) {
+	case map[string]interface{}:
+		for k, v := range typeV {
+			typeV[k], err = ModifyHashStrings(v, rm, fn)
+			if err != nil {
+				return nil, err
+			}
+		}
+	case []interface{}:
+		for i, v := range typeV {
+			typeV[i], err = ModifyHashStrings(v, rm, fn)
+			if err != nil {
+				return nil, err
+			}
+		}
+	case string:
+		// TODO (dukov) Make this more generic to replace string with map or slice
+		// instead of just go-template rendering
+		return fn(typeV, rm)
+	}
+	return doc, nil
+}


### PR DESCRIPTION
Plugin recursively walks through Kustomize resource. Once string value
has been met plugin tries to evaluate string as go template.
Plugin introduces go template function which returns subtree of
desired resource by Group Version Kind Name and JSON path

Change-Id: Ib20262c8c7b8098aa1e235b86e274372b511acb4