### PR TITLE
getTreeByPath treats values as go templates

### DIFF
--- a/pkg/document/plugins/errors.go
+++ b/pkg/document/plugins/errors.go
@@ -10,3 +10,12 @@ type UnknownPluginError struct {
 func (e UnknownPluginError) Error() string {
 	return fmt.Sprintf("Unknown airship plugin with Kind: %s", e.Kind)
 }
+
+// RenderLoopError reaisd in case of template rendeting loop
+type RenderLoopError struct {
+	Resource string
+}
+
+func (e RenderLoopError) Error() string {
+	return fmt.Sprintf("Render loop detected around %s", e.Resource)
+}

--- a/pkg/document/plugins/plugin_gotemplater_test.go
+++ b/pkg/document/plugins/plugin_gotemplater_test.go
@@ -21,15 +21,15 @@ func TestGotemplater(t *testing.T) {
 		var srcMap map[string]interface{}
 		var src []byte
 		resourceToRender, err = bundle.GetByName("resourceToRender")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		dataSource, err = bundle.GetByName("dataSource")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		renderString, err = resourceToRender.GetString("data")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		srcMap, err = dataSource.GetMap("spec.someData")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		src, err = yaml.Marshal(srcMap)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, string(src), renderString)
 	})

--- a/pkg/document/plugins/testdata/gotemplater/destination.yaml
+++ b/pkg/document/plugins/testdata/gotemplater/destination.yaml
@@ -4,3 +4,6 @@ metadata:
   name: resourceToRender
 data: |
     {{ getTreeByPath "apps_v2_Beef" "dataSource" "spec.someData" -}}
+dataForNested:
+  k1: key
+  k2: 1000

--- a/pkg/document/plugins/testdata/gotemplater/source.yaml
+++ b/pkg/document/plugins/testdata/gotemplater/source.yaml
@@ -7,3 +7,5 @@ spec:
   someData:
     test: data
     test1: otherData
+    nestedTemplate: |
+      {{ getTreeByPath "apps_v1_MeatBall" "resourceToRender" "dataForNested" -}}

--- a/pkg/document/plugins/utils.go
+++ b/pkg/document/plugins/utils.go
@@ -23,8 +23,6 @@ func ModifyHashStrings(
 			}
 		}
 	case string:
-		// TODO (dukov) Make this more generic to replace string with map or slice
-		// instead of just go-template rendering
 		return fn(typeV)
 	}
 	return doc, nil


### PR DESCRIPTION
Values referenced in getTreeByPath function are rendered as go
templates so if referenced value contains getTreeByPath it's value will
be inserted into source template and so on till all chain of values
is rendered.

Change-Id: I9c8d8a6537d4365b8cbdcf1dabf8ab3f0f1d92fb