### PR TITLE
Fix go template module

### DIFF
--- a/pkg/document/plugins/plugin_gotemplater.go
+++ b/pkg/document/plugins/plugin_gotemplater.go
@@ -3,7 +3,7 @@ package plugins
 import (
 	"bytes"
 	"fmt"
-	"html/template"
+	"text/template"
 
 	"sigs.k8s.io/kustomize/v3/pkg/gvk"
 	"sigs.k8s.io/kustomize/v3/pkg/ifc"


### PR DESCRIPTION
text module should be used since html escapes

Change-Id: If76d78734ea2ddde5aff723c966c9e9b9bc6687b